### PR TITLE
convert to .net standard 2

### DIFF
--- a/GeoCoordinate/GeoCoordinate.csproj
+++ b/GeoCoordinate/GeoCoordinate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BAMCIS.GIS</RootNamespace>
     <Authors>Michael Haken</Authors>
     <Company>bamcis.io</Company>


### PR DESCRIPTION
Converting TargetFramework to netstandard2.0 instead of .net core.  The code is already .net standard compatiable. Making this a .net standard library allows wider usage., viz Blazor